### PR TITLE
Allow configuration of the prefix use to generate vpa names

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -76,6 +76,9 @@ func main() {
 	flag.BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
 
+	flag.StringVar(&config.AutoVpaGoVpaNamePrefix, "vpa-name-prefix", "vpa-autopilot-",
+		"The prefix used to generate the name of the automatic VPA") // Warning: changing this value on an existing cluster will lead to duplicate VPAs that will need to be cleaned manually
+
 	flag.StringVar(&config.AutoVpaGoVpaLabelKey, "vpa-label-key", "vpa-autopilot-managed",
 		"The key used in the generated VPA labels to mark a VPA managed by the controller")
 	flag.StringVar(&config.AutoVpaGoVpaLabelValue, "vpa-label-value", "true",

--- a/internal/config/variables.go
+++ b/internal/config/variables.go
@@ -35,6 +35,9 @@ const (
 )
 
 var (
+	// AutoVpaGoVpaNamePrefix is the prefix used to generate the name of the automatic VPA
+	AutoVpaGoVpaNamePrefix string = "vpa-autopilot-"
+
 	// AutoVpaGoVpaLabelKey is the label key used to mark a VPA managed by the controller
 	AutoVpaGoVpaLabelKey string
 	// AutoVpaGoVpaLabelValue is the label value used to mark a VPA managed by the controller

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -41,12 +41,11 @@ func GenerateAutomaticVPA(deployment *appsv1.Deployment) (*vpav1.VerticalPodAuto
 	deploymentHash := fnv.New32a()
 	deploymentHash.Write([]byte(deployment.Name))
 	suffix := fmt.Sprint(deploymentHash.Sum32())
-	prefix := "vpa-autopilot-"
-	completeName := prefix
+	completeName := config.AutoVpaGoVpaNamePrefix
 
-	if len(deployment.Name) > 253-len(prefix)-len(suffix) {
+	if len(deployment.Name) > 253-len(config.AutoVpaGoVpaNamePrefix)-len(suffix) {
 		// If the deployment name is too long to be concatenated directly, truncate it and add sha to avoid name collision
-		completeName += deployment.Name[:253-len(prefix)-len(suffix)] + suffix
+		completeName += deployment.Name[:253-len(config.AutoVpaGoVpaNamePrefix)-len(suffix)] + suffix
 	} else {
 		// If the deployment name is reasonable, concatenate it directly
 		completeName += deployment.Name


### PR DESCRIPTION
**What type of PR is this?**
It is a feature PR

**What this PR does / why we need it**:
This PR adds a new flag in the controller in order to define the prefix of the names of the generated VPA resources. This allows the controller to run in clusters where the default prefix would not work.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #8 
