### PR TITLE
fix: fix base image for docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.23 AS builder
+FROM golang:1.25 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG GOPROXY


### PR DESCRIPTION
**What type of PR is this?**
Fix

**What this PR does / why we need it**:
It fixes artifact build by using the correct base docker image after Go upgrade to 1.25
