### PR TITLE
fix: make string equality checks case insensitive

### DIFF
--- a/internal/controller/vpa_auto_all_test.go
+++ b/internal/controller/vpa_auto_all_test.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	config "github.com/michelin/vpa-autopilot/internal/config"
@@ -307,6 +308,71 @@ var _ = Describe("VPA Auto Controllers", func() {
 
 				By(fmt.Sprintf("Creating a test %s", workloadType.Kind))
 				workload, err := testutils.GenerateTestWorkload(workloadType.Kind, hpa.Spec.ScaleTargetRef.Name)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(k8sClient.Create(ctx, workload)).To(Succeed())
+				defer func() {
+					Expect(k8sClient.Delete(ctx, workload)).To(Succeed())
+				}()
+
+				By("Checking that no automatic VPA was created")
+				Consistently(func() int {
+					vpaList := utils.FindMatchingVPA(ctx, k8sClient, workloadType.Kind, workload.GetName(), workload.GetNamespace())
+					automaticVPANumber := 0
+					for _, vpa := range vpaList {
+						if value, present := vpa.GetLabels()[config.VpaLabelKey]; present {
+							if value == config.VpaLabelValue {
+								automaticVPANumber += 1
+							}
+						}
+					}
+					return automaticVPANumber
+				}, timeout).Should(BeNumerically("==", 0))
+			})
+
+			// Test that the automatic VPA is not created if a HPA targets the same workload, even if the target kind case is different
+			It(fmt.Sprintf("Ignores the %s if a HPA targets it, even if the target kind case is different", workloadType.Kind), func() {
+				By(fmt.Sprintf("Creating a HPA for the future %s", workloadType.Kind))
+				hpa := testutils.GenerateTestClientHPA(ctx, "default", workloadType.ApiVersion, strings.ToUpper(workloadType.Kind), "testclienthpa-ignored")
+				Expect(k8sClient.Create(ctx, hpa)).To(Succeed())
+				defer func() {
+					Expect(k8sClient.Delete(ctx, hpa)).To(Succeed())
+				}()
+
+				By(fmt.Sprintf("Creating a test %s", workloadType.Kind))
+				workload, err := testutils.GenerateTestWorkload(workloadType.Kind, hpa.Spec.ScaleTargetRef.Name)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(k8sClient.Create(ctx, workload)).To(Succeed())
+				defer func() {
+					Expect(k8sClient.Delete(ctx, workload)).To(Succeed())
+				}()
+
+				By("Checking that no automatic VPA was created")
+				Consistently(func() int {
+					vpaList := utils.FindMatchingVPA(ctx, k8sClient, workloadType.Kind, workload.GetName(), workload.GetNamespace())
+					automaticVPANumber := 0
+					for _, vpa := range vpaList {
+						if value, present := vpa.GetLabels()[config.VpaLabelKey]; present {
+							if value == config.VpaLabelValue {
+								automaticVPANumber += 1
+							}
+						}
+					}
+					return automaticVPANumber
+				}, timeout).Should(BeNumerically("==", 0))
+
+			})
+
+			// Test that the automatic VPA is not created if another VPA targets the same workload, even if the target kind case is different
+			It(fmt.Sprintf("Ignores the %s if another VPA targets it, even if the target kind case is different", workloadType.Kind), func() {
+				By(fmt.Sprintf("Creating a VPA for the future %s", workloadType.Kind))
+				clientVPA := testutils.GenerateTestClientVPA(ctx, "default", workloadType.ApiVersion, strings.ToUpper(workloadType.Kind), "test-clientvpa-ignored")
+				Expect(k8sClient.Create(ctx, clientVPA)).To(Succeed())
+				defer func() {
+					Expect(k8sClient.Delete(ctx, clientVPA)).To(Succeed())
+				}()
+
+				By(fmt.Sprintf("Creating a test %s", workloadType.Kind))
+				workload, err := testutils.GenerateTestWorkload(workloadType.Kind, clientVPA.Spec.TargetRef.Name)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(k8sClient.Create(ctx, workload)).To(Succeed())
 				defer func() {

--- a/internal/controller/vpa_auto_commons.go
+++ b/internal/controller/vpa_auto_commons.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"strings"
 
 	config "github.com/michelin/vpa-autopilot/internal/config"
 	"github.com/michelin/vpa-autopilot/internal/utils"
@@ -54,7 +55,7 @@ func commonReconcile(ctx context.Context, r client.Client, workloadGVK schema.Gr
 			blockingVPAName = vpa.Name
 		}
 		for _, ownerRef := range vpa.OwnerReferences {
-			if !*ownerRef.Controller || ownerRef.Kind != workloadGVK.Kind || ownerRef.Name != workloadMetadata.Name {
+			if !*ownerRef.Controller || !strings.EqualFold(ownerRef.Kind, workloadGVK.Kind) || !strings.EqualFold(ownerRef.Name, workloadMetadata.Name) {
 				vpaPresent = true
 				blockingVPAName = vpa.Name
 				break
@@ -82,7 +83,7 @@ func commonReconcile(ctx context.Context, r client.Client, workloadGVK schema.Gr
 	// Check if one of them targets the workload
 	for _, hpa := range hpaList.Items {
 		target := hpa.Spec.ScaleTargetRef
-		if target.Kind == workloadGVK.Kind && target.APIVersion == workloadGVK.GroupVersion().String() && target.Name == workloadMetadata.Name {
+		if strings.EqualFold(target.Kind, workloadGVK.Kind) && strings.EqualFold(target.APIVersion, workloadGVK.GroupVersion().String()) && strings.EqualFold(target.Name, workloadMetadata.Name) {
 			hpaPresent = true
 			blockingHPAName = hpa.Name
 			break


### PR DESCRIPTION
**What type of PR is this?**
Bugfix

**What this PR does / why we need it**: It fixes a bug that cause a HPA and an automatic VPA to target the same workload. This can create situations where the two autoscaling tools *fight* eachother and generate instability on the application

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #40 